### PR TITLE
fix the error null value shortened url

### DIFF
--- a/boundary/src/main/java/com/example/boundary/controller/URLController.java
+++ b/boundary/src/main/java/com/example/boundary/controller/URLController.java
@@ -26,7 +26,14 @@ public class URLController {
     public ResponseEntity<URLDTO> shortenUrl(@RequestBody URLDTO urlDTO) {
 
         URL domainURL = urlDTOMapper.toDomain(urlDTO);
-        URL createdURL = urlInputPort.createUrl(domainURL);
-        return ResponseEntity.ok(urlDTOMapper.toDTO(createdURL));
+
+        String createdIdentifier= urlInputPort.shortenUrl(domainURL.getOriginalUrl());
+
+        URLDTO responseDTO = new URLDTO();
+        responseDTO.setOriginalUrl(domainURL.getOriginalUrl());
+        responseDTO.setShortenedUrl(createdIdentifier);
+
+
+        return ResponseEntity.ok(responseDTO);
     }
 }

--- a/store/src/main/java/com/example/store/entity/URLEntity.java
+++ b/store/src/main/java/com/example/store/entity/URLEntity.java
@@ -18,6 +18,8 @@ public class URLEntity {
 
     @Column(length = 2048)
     private String originalUrl;
+
+    @Column(nullable = false)
     private String shortenedUrl;
 
 


### PR DESCRIPTION
 Explanation
  - I was calling the createUrl method instead of shortenUrl in the endpoint, that's why I had a null value. 

 Closes #21 

here an example for long url and the identifier that i got 

![Screenshot 2024-10-11 at 16 02 37](https://github.com/user-attachments/assets/d72793f0-9817-4d9f-b419-2b079d3e3f5d)
